### PR TITLE
Remove require to avoid assert_private() in classroom::windows

### DIFF
--- a/manifests/npp.pp
+++ b/manifests/npp.pp
@@ -2,8 +2,6 @@ class userprefs::npp (
   $user    = 'Administrator',
   $default = true,
 )  {
-  require classroom::windows
-
   package { 'notepadplusplus':
     ensure   => present,
     provider => chocolatey,


### PR DESCRIPTION
This commit removes the 'require classroom::windows' from the userprefs::npp class.  The purpose of that require appears to be to make sure the chocolatey package is installed, before we rely on the chocolatey provider to the npp package.  However, and assert_private() in classroom::windows won't let us do this require.  The provider already checks to make sure the binary exists on the system, so we don't actually need this require() so it's the simplest solution to just remove it.
