### PR TITLE
Remove dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,7 @@ Classifying a node with classroom defaults:
 
 Contact
 -------
-ben.ford@puppetlabs.com
-js@puppetlabs.com
-education@puppetlabs.com
+ben.ford@puppetlabs.com  
+js@puppetlabs.com  
+education@puppetlabs.com  
 
-Support
--------
-
-Please log tickets and issues at our [Projects site](http://puppetlabs.com/training/issues)


### PR DESCRIPTION
The old link 404s, and the bug tracker is not visible to the public.
