### PR TITLE
Show line numbers in vim

### DIFF
--- a/files/vim/vimrc
+++ b/files/vim/vimrc
@@ -33,3 +33,6 @@ au BufRead,BufNewFile *_spec.rb
 
 " Enable indentation matching for =>'s
 filetype plugin indent on
+
+" Show line numbers
+set number


### PR DESCRIPTION
Being able to see the line numbers in VIM makes troubleshooting Puppet code easier.
