### PR TITLE
Student-provided code that prevents the whole prompt from being red

### DIFF
--- a/templates/zshrc.puppet.epp
+++ b/templates/zshrc.puppet.epp
@@ -39,7 +39,7 @@ parse_git_state() {
 # If inside a Git repository, print its branch and state
 git_prompt_string() {
   local git_where="$(parse_git_branch)"
-  [ -n "$git_where" ] && echo "$GIT_PROMPT_SYMBOL$(parse_git_state)$GIT_PROMPT_PREFIX%{$fg[red]%}${git_where#(refs/heads/|tags/)}$GIT_PROMPT_SUFFIX"
+  [ -n "$git_where" ] && echo "$GIT_PROMPT_SYMBOL$(parse_git_state)$GIT_PROMPT_PREFIX%{$fg[red]%}${git_where#(refs/heads/|tags/)}%{$reset_color%}$GIT_PROMPT_SUFFIX"
 }
 
 <% if $gitprompt { -%>


### PR DESCRIPTION
Student observed that when git is doing its "red" thing, the entire prompt is red. He provided this code to fix the issue, so that it acts the same as in bash.

I haven't had a chance to test it.
