### PR TITLE
Use of hard-coded passwords is a bad practice 

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,6 @@
+:hierarchy:
+  - common
+:backends:
+  - yaml
+:yaml:
+:datadir: 'hieradata'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,0 +1,2 @@
+---
+user_prefs_pwd: $1$hgIZHl1r$tEqMTzoXz.NBwtW3kFv33/

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -2,7 +2,7 @@ class userprefs::defaults {
   include userprefs::profile
 
   class { 'userprefs::bash':
-    password => '$1$hgIZHl1r$tEqMTzoXz.NBwtW3kFv33/',
+    password => hiera('user_prefs_pwd'),
     replace  => true,
   }
 


### PR DESCRIPTION
Greetings,

I am a security researcher, who is looking for security smells in Puppet scripts.
I noticed instances of hard-coded passwords, which are against the best practices
recommended by Common Weakness Enumeration (CWE) [https://cwe.mitre.org/data/definitions/259.html] and also by other security practitioners.
I suggest use of hiera to mitigate this smell. Feedback is welcome.
